### PR TITLE
[2022.12.13]講師マイページ修正

### DIFF
--- a/assets/sass/object/project/_mypage-calender.scss
+++ b/assets/sass/object/project/_mypage-calender.scss
@@ -1,6 +1,13 @@
 .p-mypage-calendar {
   padding-bottom: 60px;
   background: $lightgray;
+  &__schedule {
+    padding: 15px;
+    border-radius: 20px;
+    background: $lightgray;
+    display: flex;
+    justify-content: space-between;
+  }
   &__month {
     width: 100%;
     font-size: 1.4rem;

--- a/assets/sass/object/project/_mypage-mylesson-detail.scss
+++ b/assets/sass/object/project/_mypage-mylesson-detail.scss
@@ -513,6 +513,44 @@
             word-break: break-all;
           }
         }
+        &__input {
+          width: 100%;
+          background: $lightgray;
+          height: 40px;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          @media (max-width: 1024px) {
+            font-size: 12px;
+          }
+          input[type=text] {
+            max-width: 100%;
+          }
+          span {
+            font-size: 14px;
+            line-height: 14px;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-line-clamp: 1;
+            max-height: calc(1.4rem * 1);
+            color: $blue;
+            width: 100%;
+            word-break: break-all;
+          }
+          a {
+            font-size: 14px;
+            line-height: 14px;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-line-clamp: 1;
+            max-height: calc(1.4rem * 1);
+            color: $blue;
+            width: 100%;
+            word-break: break-all;
+          }
+        }
         &__right {
           width: 80px;
           color: $white;

--- a/assets/sass/object/project/_mypage-offer.scss
+++ b/assets/sass/object/project/_mypage-offer.scss
@@ -1,0 +1,468 @@
+.p-mypage-offer {
+  padding-bottom: 60px;
+  &__list {
+    width: 100%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    margin-top: 20px;
+    position: relative;
+    &__item {
+      width: 100%;
+      margin-bottom: 30px;
+      background: $white;
+      border-radius: 20px;
+      border: 1px solid $lightgray;
+      box-shadow: 0px 1px 2px rgba(0,0,0,0.08), 0px 4px 12px rgba(0,0,0,0.05);
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: column;
+      justify-content: space-between;
+      overflow: hidden;
+      position: relative;
+      @media (max-width: 1024px) {
+        width: 100%;
+        margin-right: 0;
+        margin-bottom: 20px;
+        &:nth-child(2n) {
+          margin-right: 0;
+        }
+      }
+      &__btn-wrap {
+        width: 100%;
+        display: flex;
+        &__btn {
+          width: 100%;
+          text-align: center;
+          background: $lightgray;
+          button {
+            background: none;
+            font-size: 1.2rem;
+            font-weight: bold;
+            padding: 10px 0;
+            display: block;
+            width: 100%;
+          }
+          a {
+            background: none;
+            font-size: 1.2rem;
+            font-weight: bold;
+            padding: 10px 0;
+            display: block;
+            width: 100%;
+            color: $blacktext;
+          }
+          &.accept-offer {
+            background: $maincolor;
+          }
+          &.accept {
+            background: $student;
+          }
+          &.offer01 {
+            background: $green;
+          }
+          &.offer02 {
+            background: #999;
+          }
+          &.offer03 {
+            background: $lightpink;
+          }
+        } 
+      }
+      &__wrap {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        width: 100%;
+        @media (max-width: 1024px) {
+          padding: 20px 20px 15px 20px;
+        }
+        @media (max-width: 767px) {
+          padding: 4% 4% 3% 4%;
+          align-items: flex-start;
+        }
+      }
+      &__left {
+        width: 100%;
+        padding: 30px 30px 20px 30px;
+      }
+      &__right {
+        width: 150px;
+        margin-left: 20px;
+        display: flex;
+        flex-flow: row nowrap;
+        @media (max-width: 1024px) {
+          width: 120px;
+          margin-left: 15px;
+        }
+        @media (max-width: 767px) {
+          width: 100px;
+          margin-left: 10px;
+        }
+      }
+      &__class {
+        width: 100%;
+        p {
+          display: inline-block;
+          background: $blacktext;
+          color: #FFF;
+          font-size: 1.2rem;
+          font-weight: bold;
+          margin: 2px;
+          padding: 5px 10px;
+          border-radius: 10px;
+          span {
+            background: $student;
+            color: $blacktext;
+            padding: 0 5px;
+            border-radius: 5px;
+            margin-left: 20px;
+          }
+        }
+      }
+      &__class-offer {
+        width: 100%;
+        p {
+          display: inline-block;
+          background: $blacktext;
+          color: #FFF;
+          font-size: 1.2rem;
+          font-weight: bold;
+          margin: 2px;
+          padding: 5px 10px;
+          border-radius: 10px;
+          span {
+            background: $maincolor;
+            color: $blacktext;
+            padding: 0 5px;
+            border-radius: 5px;
+            margin-left: 20px;
+          }
+        }
+      }
+      &__label {
+        display: block;
+        width: 100%;
+        max-width: fit-content;
+        background: $student;
+        padding: 6px 12px;
+        font-size: 12px;
+        line-height: 12px;
+        color: $blacktext;
+        font-weight: bold;
+        border-radius: 50px;
+        box-sizing: border-box;
+        text-align: center;
+        margin-bottom: 5px;
+        &.offer {
+          background: $maincolor;
+        }
+        @media (max-width: 1024px) {
+          padding: 4px 10px;
+          font-size: 11px;
+          line-height: 11px;
+        }
+        @media (max-width: 767px) {
+          padding: 3px 7px;
+          font-size: 10px;
+          line-height: 10px;
+        }
+      }
+      &__status {
+        display: block;
+        width: 100%;
+        max-width: fit-content;
+        background: $lightpink;
+        padding: 6px 12px;
+        font-size: 12px;
+        line-height: 12px;
+        color: #fff;
+        border-radius: 7px;
+        box-sizing: border-box;
+        text-align: center;
+        position: absolute;
+        top: 55px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 2;
+        &.pink {
+          background: $lightpink;
+        }
+        &.gray {
+          background: $darkgray;
+        }
+        @media (max-width: 1024px) {
+          padding: 4px 10px;
+          font-size: 11px;
+          line-height: 11px;
+          top: 40px;
+          letter-spacing: -0.5px;
+          min-width: 65px;
+        }
+        @media (max-width: 767px) {
+          padding: 3px 7px;
+          font-size: 10px;
+          top: 35px;
+          letter-spacing: -0.5px;
+          line-height: 10px;
+          min-width: 55px;
+        }
+      }
+      &__title {
+        font-size: 2rem;
+        font-weight: bold;
+        color: $blacktext;
+        margin-top: 5px;
+        @media (max-width: 767px) {
+          font-size: 1.6rem;
+          letter-spacing: 0.5px;
+        }
+      }
+      &__name {
+        font-size: 1.4rem;
+        line-height: 18px;
+        font-weight: 500;
+        color: $blacktext;
+        margin-bottom: 15px;
+        @media (max-width: 767px) {
+          font-size: 1.2rem;
+          line-height: 16px;
+          margin-bottom: 8px;
+          letter-spacing: 0.5px;
+        }
+      }
+      &__tiems {
+        font-size: 1.4rem;
+        line-height: 18px;
+        font-weight: 500;
+        color: $blacktext;
+        margin-bottom: 5px;
+        @media (max-width: 767px) {
+          font-size: 1.2rem;
+          line-height: 16px;
+          letter-spacing: 0.5px;
+        }
+      }
+      &__date {
+        font-size: 1.4rem;
+        line-height: 18px;
+        font-weight: 500;
+        color: $blacktext;
+        @media (max-width: 767px) {
+          font-size: 1.2rem;
+          line-height: 16px;
+          letter-spacing: 0.5px;
+        }
+      }
+      &__date-next {
+        font-size: 1.4rem;
+        line-height: 18px;
+        font-weight: bold;
+        color: $red;
+        margin: 10px 0;
+        padding: 10px;
+        background: $lightgray;
+        border-radius: 10px;
+        @media (max-width: 767px) {
+          font-size: 1.2rem;
+          line-height: 16px;
+          margin: 5px 0;
+          padding: 8px;
+          letter-spacing: 0.5px;
+        }
+      }
+      &__button {
+        width: 100%;
+        display: flex;
+        a {
+          width: 100%;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: center;
+          height: 40px;
+          background: $maincolor;
+          color: $blacktext;
+          font-size: 1.4rem;
+          font-weight: bold;
+          @media (max-width: 767px) {
+            height: 30px;
+            font-size: 1.2rem;
+          }
+          &.green {
+            background: $green;
+          }
+          &.red {
+            background: $pink;
+          }
+          &.gray {
+            background: $lightgray;
+          }
+          &.offer {
+            background: $student;
+          }
+        }
+      }
+      &__result {
+        width: 100%;
+        p {
+          width: 100%;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: center;
+          height: 40px;
+          background: $darkgray;
+          color: $white;
+          font-size: 14px;
+          .small-text {
+            font-size: 10px;
+          }
+        }
+      }
+      &__single-chart {
+        width: 100%;
+        justify-content: space-around ;
+        position: relative;
+      }
+
+      &__circular-chart {
+        display: block;
+        margin: 10px auto;
+        max-height: 250px;
+      }
+
+      &__circle-bg {
+        fill: none;
+        stroke: #eee;
+        stroke-width: 2.5;
+      }
+      &__circle {
+        fill: none;
+        stroke-width: 2.5;
+        stroke-linecap: round;
+        &.is-animated {
+          stroke: $yellow;
+          animation: progress 1s ease-out forwards;
+        }
+        &.offer {
+          stroke: $student;
+        }
+      }
+      &__percentage {
+        color: $blacktext;
+        font-size: 14px;
+        position: absolute;
+        left: 50%;
+        top: 60%;
+        text-align: center;
+        transform: translate(-50%, -50%);
+        width: 100%;
+        padding: 0 10px;
+        font-weight: 500;
+        @media (max-width: 1024px) {
+          font-size: 12px;
+          line-height: 16px;
+          top: 58%;
+        }
+        @media (max-width: 767px) {
+          font-size: 11px;
+          line-height: 14px;
+        }
+        .small-text {
+          font-size: 10px;
+          font-weight: 400;
+        }
+      }
+      @keyframes progress {
+        0% {
+          stroke-dasharray: 0 100;
+        }
+      }
+    }
+  }
+  &__search {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
+  &__search-select {
+    width: calc(22% - 20px);
+    margin-right: 20px;
+    @media (max-width: 767px) {
+      width: calc(28% - 10px);
+      margin-right: 10px;
+    }
+    .c-select {
+      width: 100% !important;
+      &:after {
+        @media (max-width: 767px) {
+          right: 10px !important;
+        }
+      }
+    }
+    select {
+      background: $lightgray !important;
+      font-size: 12px !important;
+      font-weight: 400 !important;
+      border-radius: 20px !important;
+      border: none !important;
+    }
+  }
+  &__search-icon-box {
+    width: 78%;
+    @media (max-width: 767px) {
+      width: 72%;
+    }
+    &__btn {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      input {
+        height: 44px;
+        padding: 10px 60px 10px 20px;
+        border-top-left-radius: 20px;
+        border-bottom-left-radius: 20px;
+        background: #FFF;
+        background: $lightgray;
+        max-width: none;
+      }
+      &__btn {
+        background: $maincolor;
+        width: 52px;
+        height: 44px;
+        text-align: center;
+        font-size: 2.2rem;
+        font-weight: bold;
+        display: inline-block;
+        padding: 10px 20px;
+        border-top-right-radius: 20px;
+        border-bottom-right-radius: 20px;
+        color: $blacktext;
+        transition: all 0.2s ease;
+        position: relative;
+        font-weight: bold;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        @media (max-width: 767px) {
+          font-size: 1.4rem;
+          width: 40px;
+        }
+        i {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -56,6 +56,7 @@
 @import "object/project/mypage-mylesson";
 @import "object/project/mypage-mylesson-detail";
 @import "object/project/mypage-calender";
+@import "object/project/mypage-offer";
 @import "object/project/company";
 @import "object/project/news";
 @import "object/project/contact";
@@ -66,4 +67,3 @@
 @import "object/project/userpage-lesson-list";
 @import "object/project/userpage-offer-list";
 @import "object/project/userpage-lesson-confirm";
-

--- a/include/tutor-aside.html
+++ b/include/tutor-aside.html
@@ -1,124 +1,121 @@
-<div class="l-aside__profile">
-  <div class="l-aside__profile__img">
-    <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-    <span class="l-aside__profile__img__label">의뢰인</span>
+<aside class="l-aside">
+  <div class="l-aside__profile">
+    <div class="l-aside__profile__left">
+      <div class="l-aside__profile__img">
+        <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+        <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+      </div>
+      <p class="l-aside__profile__title">
+        UserName
+      </p>
+    </div>
+    <div class="l-aside__profile__right">
+      <div class="l-aside__profile__title__quickmenu">
+        <a href="mypage-offer.html">
+          <p>オファー</p>
+            10<span>件</span>
+        </a>
+        <a href="mypage-offer.html">
+          <p>指名</p>
+            12<span>件</span>
+        </a>
+      </div>
+      <div class="l-aside__profile__title__button">
+        <a href="mypage-profile.html">
+          <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+        </a>
+        <a href="mypage-lesson-mylesson.html">
+          <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+        </a>
+      </div>
+    </div>
   </div>
-  <p class="l-aside__profile__title">
-    제이비드 킴
-  </p>
-  <div class="l-aside__profile__title__button">
-    <a href="#">
-      <img src="assets/images/mypage/aside_icon_01.png" alt="">전문가로 전환
-    </a>
+  <div class="l-aside__button">
+    メニューを見る
   </div>
-</div>
-<h3 class="l-aside__title">
-  마이페이지
-</h3>
-<ul class="l-aside__nav">
-  <li class="l-aside__nav__item">
-    <div class="l-aside__nav__link-wrap">
-      <a href="" class="l-aside__nav__link">
-        プロフィール
-      </a>
-      <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
-    </div>
-    <ul class="l-aside__nav__hide">
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          전체 (0)
+  <ul class="l-aside__nav">
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-ballot-check"></i>ダッシュボード
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          승인대기중 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-notice.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-bullhorn"></i>お知らせ
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          요청중 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-profile.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-id-card-clip"></i>プロフィール管理
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          마감 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-calendar.html" class="l-aside__nav__link">
+          <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          비승인 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-offer.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-hand"></i>オファー・指名管理
         </a>
-      </li>
-    </ul>
-  </li>
-  <li class="l-aside__nav__item">
-    <div class="l-aside__nav__link-wrap">
-      <a href="" class="l-aside__nav__link">
-        レッスン登録
-      </a>
-      <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
-    </div>
-    <ul class="l-aside__nav__hide">
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          전체 (0)
+      </div>
+    </li> 
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="" class="l-aside__nav__link">
+          <i class="fa-solid fa-person-chalkboard"></i>レッスン管理
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          승인대기중 (0)
+        <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
+      </div>
+      <ul class="l-aside__nav__hide" style="display: block;">       
+        <li class="l-aside__nav__hide__item">
+          <a href="mypage-lesson-mylesson.html" class="">
+            <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
+          </a>
+        </li>
+        <li class="l-aside__nav__hide__item">
+          <a href="mypage-lesson-mylesson-complete.html" class="">
+            <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
+          </a>
+        </li>
+      </ul>
+    </li>         
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-message.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-message"></i>メッセージ
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          요청중 (0)
+      </div>
+    </li>          
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-wishlist.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-heart"></i>お気に入り
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          마감 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="mypage-payment.html" class="l-aside__nav__link">
+          <i class="fa-regular fa-credit-card"></i>売上管理
         </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          비승인 (0)
+      </div>
+    </li>
+    <li class="l-aside__nav__item">
+      <div class="l-aside__nav__link-wrap">
+        <a href="" class="l-aside__nav__link">
+          <i class="fa-solid fa-arrow-right-from-bracket"></i>ログアウト
         </a>
-      </li>
-    </ul>
-  </li>
-  <li class="l-aside__nav__item">
-    <div class="l-aside__nav__link-wrap">
-      <a href="" class="l-aside__nav__link">
-        スケジュール登録
-      </a>
-      <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion is-open"></a>
-    </div>
-    <ul class="l-aside__nav__hide" style="display: block;">
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="is-active">
-          전체 (0)
-        </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          승인대기중 (0)
-        </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          요청중 (0)
-        </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          마감 (0)
-        </a>
-      </li>
-      <li class="l-aside__nav__hide__item">
-        <a href="" class="">
-          비승인 (0)
-        </a>
-      </li>
-    </ul>
-  </li>
-</ul>
+      </div>
+    </li>
+  </ul>
+</aside>

--- a/mypage-calendar.html
+++ b/mypage-calendar.html
@@ -47,20 +47,20 @@
           </div>
           <div class="l-aside__profile__right">
             <div class="l-aside__profile__title__quickmenu">
-              <a href="userpage-ticket.html">
+              <a href="mypage-offer.html">
                 <p>オファー</p>
                   10<span>件</span>
               </a>
-              <a href="mypage-lesson-mylesson.html">
+              <a href="mypage-offer.html">
                 <p>指名</p>
                   12<span>件</span>
               </a>
             </div>
             <div class="l-aside__profile__title__button">
-              <a href="userpage-profile.html">
+              <a href="mypage-profile.html">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
               </a>
-              <a href="userpage-lesson.html">
+              <a href="mypage-lesson-mylesson.html">
                 <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
               </a>
             </div>
@@ -79,6 +79,13 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
               <a href="mypage-profile.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール管理
               </a>
@@ -86,22 +93,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
                 <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール登録
+              <a href="mypage-offer.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-hand"></i>オファー管理
               </a>
             </div>
-          </li>
+          </li> 
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファー・指名管理
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -121,11 +128,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>
@@ -163,7 +165,11 @@
       <div class="l-container main">
         <div class="p-mypage-calendar">
           <section class="l-section">
-            <h2 class="c-title"><span>スケジュールカレンダー(GMT+9)</span></h2>     
+            <h2 class="c-title"><span>スケジュールカレンダー(GMT+9)</span></h2>
+              <div class="p-mypage-calendar__schedule">
+                <p class="p-mypage-calendar__schedule__title">スケジュールをより詳しく入力すると生徒からの指名がもっとスムーズになります。</p>
+                <a href="mypage-schedule.html" class="p-mypage-calendar__schedule__link">スケジュール登録</a>
+              </div>
               <div class="p-mypage-calendar__info">
                 <div class="p-mypage-calendar__info__text">
                   <span class="schedule"></span> レッスン

--- a/mypage-lesson-complete.html
+++ b/mypage-lesson-complete.html
@@ -196,24 +196,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -226,29 +253,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -259,12 +279,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -273,11 +288,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-lesson-list.html
+++ b/mypage-lesson-list.html
@@ -36,24 +36,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -66,29 +93,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -99,12 +119,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -113,11 +128,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-lesson-mylesson-detail.html
+++ b/mypage-lesson-mylesson-detail.html
@@ -36,24 +36,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -66,29 +93,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -99,12 +119,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -113,11 +128,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>
@@ -214,14 +224,11 @@
                     <p class="p-mypage-mylesson-detail__list__item__date">2022.10.30 15:00</p>
                     <p class="p-mypage-mylesson-detail__list__item__code__title">参加コード</p>
                     <div class="p-mypage-mylesson-detail__list__item__code">
-                      <p class="p-mypage-mylesson-detail__list__item__code__left">
-                        <a href="zoom.com/dfsdfdsfdsfdsfdsfdsfdshfjdks" class="js-copytext">zoom.com/dfsdfdsfdsfdsfdsfdsfdshfjdks</a>
+                      <p class="p-mypage-mylesson-detail__list__item__code__input">
+                        <input type="text" value="googlemeetttttttttttttt">
                       </p>
-                      <p class="p-mypage-mylesson-detail__list__item__code__right js-copybtn">
-                        コピー
-                      </p>
-                      <p class="p-mypage-mylesson-detail__list__item__code__alert js-copyalert">
-                        コピーしました
+                      <p class="p-mypage-mylesson-detail__list__item__code__right">
+                        修正
                       </p>
                     </div>
                   </div>
@@ -240,14 +247,11 @@
                     <p class="p-mypage-mylesson-detail__list__item__date">2022.11.10 15:00</p>
                     <p class="p-mypage-mylesson-detail__list__item__code__title">参加コード</p>
                     <div class="p-mypage-mylesson-detail__list__item__code">
-                      <p class="p-mypage-mylesson-detail__list__item__code__left">
-                        <a href="zoom.com/dfsdfdsfdsfdsfdsfdsfdshfjdks" class="js-copytext">zoom.com/dfsdfdsfdsfdsfdshfjdks</a>
+                      <p class="p-mypage-mylesson-detail__list__item__code__input">
+                        <input type="text">
                       </p>
-                      <p class="p-mypage-mylesson-detail__list__item__code__right js-copybtn">
-                        コピー
-                      </p>
-                      <p class="p-mypage-mylesson-detail__list__item__code__alert js-copyalert">
-                        コピーしました
+                      <p class="p-mypage-mylesson-detail__list__item__code__right">
+                        登録
                       </p>
                     </div>
                   </div>
@@ -265,8 +269,11 @@
                     <p class="p-mypage-mylesson-detail__list__item__date">2022.11.20 15:00</p>
                     <p class="p-mypage-mylesson-detail__list__item__code__title">参加コード</p>
                     <div class="p-mypage-mylesson-detail__list__item__code">
-                      <p class="p-mypage-mylesson-detail__list__item__code__left">
-                        <span>24時間前から表示されます。</span>
+                      <p class="p-mypage-mylesson-detail__list__item__code__input">
+                        <input type="text">
+                      </p>
+                      <p class="p-mypage-mylesson-detail__list__item__code__right">
+                        登録
                       </p>
                     </div>
                   </div>
@@ -284,8 +291,11 @@
                     <p class="p-mypage-mylesson-detail__list__item__date">2022.11.27 15:00</p>
                     <p class="p-mypage-mylesson-detail__list__item__code__title">参加コード</p>
                     <div class="p-mypage-mylesson-detail__list__item__code">
-                      <p class="p-mypage-mylesson-detail__list__item__code__left">
-                        <span>24時間前から表示されます。</span>
+                      <p class="p-mypage-mylesson-detail__list__item__code__input">
+                        <input type="text">
+                      </p>
+                      <p class="p-mypage-mylesson-detail__list__item__code__right">
+                        登録
                       </p>
                     </div>
                   </div>

--- a/mypage-lesson-mylesson.html
+++ b/mypage-lesson-mylesson.html
@@ -36,24 +36,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -66,29 +93,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -99,12 +119,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -113,11 +128,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-link.html
+++ b/mypage-link.html
@@ -196,24 +196,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -226,29 +253,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -259,12 +279,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -273,11 +288,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-message.html
+++ b/mypage-message.html
@@ -196,24 +196,51 @@
     <div class="l-content">
       <aside class="l-aside">
         <div class="l-aside__profile">
-          <div class="l-aside__profile__img">
-            <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
-            <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+          <div class="l-aside__profile__left">
+            <div class="l-aside__profile__img">
+              <img src="assets/images/mypage/aside_img_01.png" alt="プロフィールイメージ">
+              <span class="l-aside__profile__img__label"><i class="fa-sharp fa-solid fa-shield-check"></i>承認済み</span>
+            </div>
+            <p class="l-aside__profile__title">
+              UserName
+            </p>
           </div>
-          <p class="l-aside__profile__title">
-            Valeria Elsa
-          </p>
-          <div class="l-aside__profile__title__button">
-            <a href="mypage-profile.html">
-              <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
-            </a>
+          <div class="l-aside__profile__right">
+            <div class="l-aside__profile__title__quickmenu">
+              <a href="mypage-offer.html">
+                <p>オファー</p>
+                  10<span>件</span>
+              </a>
+              <a href="mypage-offer.html">
+                <p>指名</p>
+                  12<span>件</span>
+              </a>
+            </div>
+            <div class="l-aside__profile__title__button">
+              <a href="mypage-profile.html">
+                <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
+              </a>
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
+              </a>
+            </div>
           </div>
         </div>
-        <ul class="l-aside__nav">          
+        <div class="l-aside__button">
+          メニューを見る
+        </div>
+        <ul class="l-aside__nav">
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-ballot-check"></i>ダッシュボード
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
               </a>
             </div>
           </li>
@@ -226,29 +253,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -259,12 +279,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -273,11 +288,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-nomination.html
+++ b/mypage-nomination.html
@@ -163,11 +163,11 @@
         </ul>
       </aside>
       <div class="l-container main">
-        <div class="p-mypage-mylesson">
+        <div class="p-mypage-offer">
           <section class="l-section">
-            <h2 class="c-title"><span>受講完了のレッスン</span></h2>
-            <div class="p-mypage-mylesson__search">
-              <div class="p-mypage-mylesson__search-select">
+            <h2 class="c-title"><span>受講中のレッスン</span></h2>
+            <div class="p-mypage-offer__search">
+              <div class="p-mypage-offer__search-select">
                 <div class="c-select__wrapper">
                   <div class="c-select">
                     <select class="selected__color" name="" id="">
@@ -178,113 +178,57 @@
                   </div>
                 </div>
               </div>
-              <div class="p-mypage-mylesson__search-icon-box">
-                <div class="p-mypage-mylesson__search-icon-box__btn">
+              <div class="p-mypage-offer__search-icon-box">
+                <div class="p-mypage-offer__search-icon-box__btn">
                   <input type="text" placeholder="keyword...">
-                  <button class="p-mypage-mylesson__search-icon-box__btn__btn">
+                  <button class="p-mypage-offer__search-icon-box__btn__btn">
                     <i class="fa-light fa-magnifying-glass"></i>
                   </button>
                 </div>
               </div>
             </div>
-            <ul class="p-mypage-mylesson__list">
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label">レッスン</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+            <ul class="p-mypage-offer__list">
+              <li class="p-mypage-offer__list__item">
+                <div class="p-mypage-offer__list__item__wrap">
+                  <div class="p-mypage-offer__list__item__left">
+                    <div class="p-mypage-offer__list__item__label">指名</div>
+                    <h3 class="p-mypage-offer__list__item__title">生徒の名前</h3>
+                    <div class="p-mypage-offer__list__item__tiems">指名回数 4回</div>
+                    <div class="p-mypage-offer__list__item__class">
+                      <p>2022.12.13 15:00~ <span>20分</span></p>
+                      <p>2022.12.13 19:00~ <span>45分</span></p>
+                      <p>2022.12.13 21:00~ <span>20分</span></p>
+                      <p>2022.12.13 22:00~ <span>20分</span></p>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
+                  <div class="p-mypage-offer__list__item__btn-wrap">
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn accept">
+                      <button>承知する</button>
+                    </div>
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn refusal">
+                      <button>断る</button>
+                    </div>
+                  </div>
                 </div>
               </li>
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label offer">レッスン希望</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+              <li class="p-mypage-offer__list__item">
+                <div class="p-mypage-offer__list__item__wrap">
+                  <div class="p-mypage-offer__list__item__left">
+                    <div class="p-mypage-offer__list__item__label">指名</div>
+                    <h3 class="p-mypage-offer__list__item__title">生徒の名前</h3>
+                    <div class="p-mypage-offer__list__item__tiems">指名回数 4回</div>
+                    <div class="p-mypage-offer__list__item__class">
+                      <p>2022.12.13 15:00~ <span>20分</span></p>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
-                </div>
-              </li>
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label">レッスン</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+                  <div class="p-mypage-offer__list__item__btn-wrap">
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn accept">
+                      <button>承知する</button>
+                    </div>
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn refusal">
+                      <button>断る</button>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
                 </div>
               </li>
             </ul>

--- a/mypage-notice.html
+++ b/mypage-notice.html
@@ -323,66 +323,148 @@
         </ul>
       </aside>
       <div class="l-container main">
-        <div class="p-mypage-profile">
+        <div class="p-userpage">
           <section class="l-section">
-            <h2 class="c-title"><span>レッスン登録</span></h2>
-            <!--<p class="c-calendar__alert">*カレンダーからご希望の日付を選択し、スケジュールを選択してください。</p>-->
-            <form class="" action="" method="post">
-              <div class="c-input__col">
-                <div class="c-input">
-                  <p class="c-input__title">教える言語</p>
-                  <input class="" type="text" id="" placeholder="教える言語" value="英語" readonly/>
-                  <span class="c-input__cheack"><i class="fa-solid fa-circle-check"></i></span>
+            <div class="p-userpage__notify">
+              <h2 class="c-title"><span>新着お知らせ</span></h2>
+              <div class="p-userpage__notify__contents">
+                <ul class="p-userpage__notify__list">
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-lesson-list.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>講師名様からレッスンオファーがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-message.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>メッセージ</span>講師名様から新着メッセージがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="mypage-lesson-mylesson-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>レッスンが始まるまで１時間前です。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-notice-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>お知らせ</span>同じ講師の２回目のレッスンは指名料がかかります。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-lesson-list.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>講師名様からレッスンオファーがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-message.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>メッセージ</span>講師名様から新着メッセージがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="mypage-lesson-mylesson-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>レッスンが始まるまで１時間前です。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-notice-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>お知らせ</span>同じ講師の２回目のレッスンは指名料がかかります。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-lesson-list.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>講師名様からレッスンオファーがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-message.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>メッセージ</span>講師名様から新着メッセージがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="mypage-lesson-mylesson-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>レッスンが始まるまで１時間前です。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-notice-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>お知らせ</span>同じ講師の２回目のレッスンは指名料がかかります。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  
+                </ul>
+                <div class="p-userpage__notify__none">
+                  新着アラームがありません。
+                </div>
+                <div class="c-paging">
+                  <a href="" class="c-paging__maincolor__link active">1</a>
+                  <a href="" class="c-paging__maincolor__link">2</a>
+                  <a href="" class="c-paging__maincolor__link">3</a>
+                  <a href="" class="c-paging__maincolor__link">4</a>
+                  <a href="" class="c-paging__maincolor__link">5</a>
+                  <a href="" class="c-paging__maincolor__link"><i class="fa-regular fa-angle-right"></i></a>
+                  <a href="" class="c-paging__maincolor__link"><i class="fa-solid fa-angles-right"></i></a>
                 </div>
               </div>
-              <div class="c-input__col">
-                <div class="c-input">
-                  <p class="c-input__title">レッスンタイトル</p>
-                  <input class="" type="text" id="" placeholder="レッスンタイトル" >
-                </div>
-              </div>
-              <div class="c-checkbox">
-                <p class="c-checkbox__title">レッスンレベル<span>※重複選択可能</span></p>
-                <div class="c-checkbox__flex">
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_01" name="level" value="">
-                    <label for="level_01">初心者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_02" name="level" value="">
-                    <label for="level_02">中級者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_03" name="level" value="">
-                    <label for="level_03">上級者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_04" name="level" value="">
-                    <label for="level_04">ビジネス</label>
-                  </div>
-                </div>
-              </div>
-              <div class="c-checkbox">
-                <p class="c-checkbox__title">レッスン時間<span>※重複選択可能</span></p>
-                <div class="c-checkbox__flex__2col">
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="curse_01" name="curse" value="">
-                    <label for="curse_01">20分コース</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="curse_02" name="curse" value="">
-                    <label for="curse_02">45分コース</label>
-                  </div>
-                </div>
-              </div>
-              <div class="c-textarea">
-                <p class="c-textarea__title">レッスン詳細内容</p>
-                <textarea class="textarea-160 textarea-resize" name="" placeholder="レッスン詳細内容"></textarea><br>
-              </div>
-              <div class="p-mypage-profile__submit">
-                <button class="js-sumit" onclick="location.href='mypage-lesson-complete.html'">プロフィール編集</button>
-              </div>
-            </form>
+            </div>
           </section>
         </div>
       </div>

--- a/mypage-offer.html
+++ b/mypage-offer.html
@@ -163,11 +163,11 @@
         </ul>
       </aside>
       <div class="l-container main">
-        <div class="p-mypage-mylesson">
+        <div class="p-mypage-offer">
           <section class="l-section">
-            <h2 class="c-title"><span>受講完了のレッスン</span></h2>
-            <div class="p-mypage-mylesson__search">
-              <div class="p-mypage-mylesson__search-select">
+            <h2 class="c-title"><span>受講中のレッスン</span></h2>
+            <div class="p-mypage-offer__search">
+              <div class="p-mypage-offer__search-select">
                 <div class="c-select__wrapper">
                   <div class="c-select">
                     <select class="selected__color" name="" id="">
@@ -178,113 +178,80 @@
                   </div>
                 </div>
               </div>
-              <div class="p-mypage-mylesson__search-icon-box">
-                <div class="p-mypage-mylesson__search-icon-box__btn">
+              <div class="p-mypage-offer__search-icon-box">
+                <div class="p-mypage-offer__search-icon-box__btn">
                   <input type="text" placeholder="keyword...">
-                  <button class="p-mypage-mylesson__search-icon-box__btn__btn">
+                  <button class="p-mypage-offer__search-icon-box__btn__btn">
                     <i class="fa-light fa-magnifying-glass"></i>
                   </button>
                 </div>
               </div>
             </div>
-            <ul class="p-mypage-mylesson__list">
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label">レッスン</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+            <ul class="p-mypage-offer__list">
+              <li class="p-mypage-offer__list__item">
+                <div class="p-mypage-offer__list__item__wrap">
+                  <div class="p-mypage-offer__list__item__left">
+                    <div class="p-mypage-offer__list__item__label offer">オファー</div>
+                    <h3 class="p-mypage-offer__list__item__title">生徒の名前</h3>
+                    <div class="p-mypage-offer__list__item__tiems">指名回数 4回</div>
+                    <div class="p-mypage-offer__list__item__class-offer">
+                      <p>2022.12.13 15:00~ <span>20分</span></p>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
+                  <div class="p-mypage-offer__list__item__btn-wrap">
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn offer01">
+                      <button>オファー承諾待ち</button>
+                    </div>
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn refusal">
+                      <button>キャンセル</button>
+                    </div>
+                  </div>
                 </div>
               </li>
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label offer">レッスン希望</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+              <li class="p-mypage-offer__list__item">
+                <div class="p-mypage-offer__list__item__wrap">
+                  <div class="p-mypage-offer__list__item__left">
+                    <div class="p-mypage-offer__list__item__label offer">オファー</div>
+                    <h3 class="p-mypage-offer__list__item__title">生徒の名前</h3>
+                    <div class="p-mypage-offer__list__item__tiems">指名回数 4回</div>
+                    <div class="p-mypage-offer__list__item__class-offer">
+                      <p>2022.12.13 15:00~ <span>20分</span></p>
+                      <p>2022.12.13 19:00~ <span>45分</span></p>
+                      <p>2022.12.13 21:00~ <span>20分</span></p>
+                      <p>2022.12.13 22:00~ <span>20分</span></p>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
+                  <div class="p-mypage-offer__list__item__btn-wrap">
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn offer02">
+                      <button>オファー拒絶</button>
+                    </div>
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn refusal">
+                      <button>削除</button>
+                    </div>
+                  </div>
                 </div>
               </li>
-              <li class="p-mypage-mylesson__list__item">
-                <div class="p-mypage-mylesson__list__item__wrap">
-                  <div class="p-mypage-mylesson__list__item__left">
-                    <p class="p-mypage-mylesson__list__item__label">レッスン</p>
-                    <h3 class="p-mypage-mylesson__list__item__title">レッスンタイトル</h3>
-                    <p class="p-mypage-mylesson__list__item__name">生徒の名前</p>
-                    <p class="p-mypage-mylesson__list__item__tiems">購入回数 4回</p>
-                    <p class="p-mypage-mylesson__list__item__date">レッスン期間 2022.10.30 ~ 2022.12.01</p>
-                  </div>
-                  <div class="p-mypage-mylesson__list__item__right">
-                    <div class="p-mypage-mylesson__list__item__single-chart">
-                      <p class="p-mypage-mylesson__list__item__percentage">100%<span class="small-text"> 完了</span><br />4回／<span class="small-text">全4回</span></p>
-                      <p class="p-mypage-mylesson__list__item__status gray">受講完了</p>
-                      <svg viewBox="0 0 36 36" class="p-mypage-mylesson__list__item__circular-chart orange">
-                        <path class="p-mypage-mylesson__list__item__circle-bg"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                        <path class="p-mypage-mylesson__list__item__circle scroll-animation"
-                          stroke-dasharray="100, 100"
-                          d="M18 2.0845
-                            a 15.9155 15.9155 0 0 1 0 31.831
-                            a 15.9155 15.9155 0 0 1 0 -31.831"
-                        />
-                      </svg>
+              <li class="p-mypage-offer__list__item">
+                <div class="p-mypage-offer__list__item__wrap">
+                  <div class="p-mypage-offer__list__item__left">
+                    <div class="p-mypage-offer__list__item__label offer">オファー</div>
+                    <h3 class="p-mypage-offer__list__item__title">生徒の名前</h3>
+                    <div class="p-mypage-offer__list__item__tiems">指名回数 4回</div>
+                    <div class="p-mypage-offer__list__item__class-offer">
+                      <p>2022.12.13 15:00~ <span>20分</span></p>
+                      <p>2022.12.13 19:00~ <span>45分</span></p>
+                      <p>2022.12.13 21:00~ <span>20分</span></p>
+                      <p>2022.12.13 22:00~ <span>20分</span></p>
                     </div>
                   </div>
-                </div>
-                <div class="p-mypage-mylesson__list__item__button">
-                  <a href="mypage-lesson-mylesson-detail.html" class="gray">全4回</span>　完了しました。</a>
+                  <div class="p-mypage-offer__list__item__btn-wrap">
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn accept-offer">
+                      <button>オファー承諾</button>
+                    </div>
+                    <div class="p-mypage-offer__list__item__btn-wrap__btn refusal">
+                      <a href="mypage-lesson-mylesson.html">レッスンページへ</a>
+                    </div>
+                  </div>
                 </div>
               </li>
             </ul>

--- a/mypage-profile.html
+++ b/mypage-profile.html
@@ -207,21 +207,21 @@
           </div>
           <div class="l-aside__profile__right">
             <div class="l-aside__profile__title__quickmenu">
-              <a href="userpage-ticket.html">
-                <p>指名中</p>
+              <a href="mypage-offer.html">
+                <p>オファー</p>
                   10<span>件</span>
               </a>
-              <a href="mypage-lesson-mylesson.html">
-                <p>オファー中</p>
+              <a href="mypage-offer.html">
+                <p>指名</p>
                   12<span>件</span>
               </a>
             </div>
             <div class="l-aside__profile__title__button">
-              <a href="userpage-profile.html">
+              <a href="mypage-profile.html">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
               </a>
-              <a href="userpage-lesson.html">
-                <i class="fa-regular fa-circle-plus"></i>受講中のレッスン
+              <a href="mypage-lesson-mylesson.html">
+                <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
               </a>
             </div>
           </div>
@@ -239,6 +239,13 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
               <a href="mypage-profile.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール管理
               </a>
@@ -246,29 +253,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-link.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-laptop"></i>Zoom/Googlemeet管理
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
-                <i class="fa-solid fa-chalkboard"></i>レッスン登録
-              </a>
-            </div>
-          </li>
-          <li class="l-aside__nav__item">
-            <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
               <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+                <i class="fa-regular fa-hand"></i>オファー管理
+              </a>
+            </div>
+          </li> 
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -279,12 +279,7 @@
               </a>
               <a href="javascript:void(0);" class="l-aside__nav__link__arrow js-aside-accordion"></a>
             </div>
-            <ul class="l-aside__nav__hide" style="display: block;">
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-list.html" class="">
-                  <i class="fa-solid fa-circle-dot yellow"></i>登録中 (0)
-                </a>
-              </li>         
+            <ul class="l-aside__nav__hide" style="display: block;">       
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson.html" class="">
                   <i class="fa-solid fa-circle-dot grren"></i>受講中 (0)
@@ -293,11 +288,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage-schedule.html
+++ b/mypage-schedule.html
@@ -47,20 +47,20 @@
           </div>
           <div class="l-aside__profile__right">
             <div class="l-aside__profile__title__quickmenu">
-              <a href="userpage-ticket.html">
-                <p>オファー中</p>
+              <a href="mypage-offer.html">
+                <p>オファー</p>
                   10<span>件</span>
               </a>
-              <a href="mypage-lesson-mylesson.html">
-                <p>指名中</p>
+              <a href="mypage-offer.html">
+                <p>指名</p>
                   12<span>件</span>
               </a>
             </div>
             <div class="l-aside__profile__title__button">
-              <a href="userpage-profile.html">
+              <a href="mypage-profile.html">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール編集
               </a>
-              <a href="userpage-lesson.html">
+              <a href="mypage-lesson-mylesson.html">
                 <i class="fa-solid fa-person-chalkboard"></i>受講中のレッスン
               </a>
             </div>
@@ -79,6 +79,13 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
+              <a href="mypage-notice.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-bullhorn"></i>お知らせ
+              </a>
+            </div>
+          </li>
+          <li class="l-aside__nav__item">
+            <div class="l-aside__nav__link-wrap">
               <a href="mypage-profile.html" class="l-aside__nav__link">
                 <i class="fa-regular fa-id-card-clip"></i>プロフィール管理
               </a>
@@ -86,22 +93,22 @@
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-lesson.html" class="l-aside__nav__link">
+              <a href="mypage-calendar.html" class="l-aside__nav__link">
                 <i class="fa-solid fa-chalkboard"></i>レッスンカレンダー
               </a>
             </div>
           </li>
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-schedule.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-calendar-lines-pen"></i>スケジュール管理
+              <a href="mypage-offer.html" class="l-aside__nav__link">
+                <i class="fa-regular fa-hand"></i>オファー管理
               </a>
             </div>
-          </li>
+          </li> 
           <li class="l-aside__nav__item">
             <div class="l-aside__nav__link-wrap">
-              <a href="mypage-offer.html" class="l-aside__nav__link">
-                <i class="fa-regular fa-hand"></i>オファーしたレッスン希望
+              <a href="mypage-nomination.html" class="l-aside__nav__link">
+                <i class="fa-solid fa-thumbs-up"></i>指名管理
               </a>
             </div>
           </li> 
@@ -121,11 +128,6 @@
               <li class="l-aside__nav__hide__item">
                 <a href="mypage-lesson-mylesson-complete.html" class="">
                   <i class="fa-solid fa-circle-dot blue"></i>受講完了 (0)
-                </a>
-              </li>
-              <li class="l-aside__nav__hide__item">
-                <a href="mypage-lesson-mylesson-cancel.html" class="">
-                  <i class="fa-regular fa-circle-xmark red"></i>キャンセル (0)
                 </a>
               </li>
             </ul>

--- a/mypage.html
+++ b/mypage.html
@@ -323,66 +323,197 @@
         </ul>
       </aside>
       <div class="l-container main">
-        <div class="p-mypage-profile">
+        <div class="p-userpage">
           <section class="l-section">
-            <h2 class="c-title"><span>レッスン登録</span></h2>
-            <!--<p class="c-calendar__alert">*カレンダーからご希望の日付を選択し、スケジュールを選択してください。</p>-->
-            <form class="" action="" method="post">
-              <div class="c-input__col">
-                <div class="c-input">
-                  <p class="c-input__title">教える言語</p>
-                  <input class="" type="text" id="" placeholder="教える言語" value="英語" readonly/>
-                  <span class="c-input__cheack"><i class="fa-solid fa-circle-check"></i></span>
+            <div class="p-userpage__dashboard">
+              <ul class="p-userpage__dashboard__list">
+                <li class="p-userpage__dashboard__list__item">
+                  指名
+                  <span>3件</span>
+                  <a href="userpage-offer-list.html">確認する</a>
+                </li>
+                <li class="p-userpage__dashboard__list__item">
+                  オファー
+                  <span>0件</span>
+                  <a href="userpage-message.html">確認する</a>
+                </li>
+                <li class="p-userpage__dashboard__list__item">
+                  メッセージ
+                  <span>3件</span>
+                  <a href="userpage-lesson-list.html">確認する</a>
+                </li>
+                <li class="p-userpage__dashboard__list__item">
+                  受講中
+                  <span>3件</span>
+                  <a href="userpage-lesson-mylesson.html">確認する</a>
+                </li>
+              </ul>
+            </div>
+            <div class="p-userpage__notify">
+              <h2 class="c-title"><span>新着お知らせ</span></h2>
+              <div class="p-userpage__notify__contents">
+                <ul class="p-userpage__notify__list">
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-lesson-list.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>生徒名様からレッスン指名がありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-message.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>メッセージ</span>生徒名様から新着メッセージがありました。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="mypage-lesson-mylesson-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span class="lesson">レッスン</span>レッスンが始まるまで１時間前です。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__notify__list__item">
+                    <a href="userpage-notice-detail.html">
+                      <div class="p-userpage__notify__list__item__title">
+                        <span>お知らせ</span>同じ講師の２回目のレッスンは指名料がかかります。
+                      </div>
+                      <div class="p-userpage__notify__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                    </a>
+                  </li>
+                </ul>
+                <div class="p-userpage__notify__none">
+                  新着アラームがありません。
                 </div>
               </div>
-              <div class="c-input__col">
-                <div class="c-input">
-                  <p class="c-input__title">レッスンタイトル</p>
-                  <input class="" type="text" id="" placeholder="レッスンタイトル" >
+            </div>
+            <div class="p-userpage__ticket">
+              <h2 class="c-title"><span>今月の売上</span></h2>
+              <div class="p-userpage__ticket__content">
+                <dl>
+                  <dt>S Class(20分)</dt>
+                  <dd>3件</dd>
+                  <dd>$45</dd>                     
+                  <dt>M Class(45分)</dt>
+                  <dd>1件</dd>
+                  <dd>$45</dd>        
+                  <dt>指名</dt>
+                  <dd>3件</dd>
+                  <dd>$45</dd>          
+                </dl>
+                <div class="p-userpage__ticket__link">
+                  <a href="">詳しく見る</a>
                 </div>
               </div>
-              <div class="c-checkbox">
-                <p class="c-checkbox__title">レッスンレベル<span>※重複選択可能</span></p>
-                <div class="c-checkbox__flex">
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_01" name="level" value="">
-                    <label for="level_01">初心者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_02" name="level" value="">
-                    <label for="level_02">中級者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_03" name="level" value="">
-                    <label for="level_03">上級者</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="level_04" name="level" value="">
-                    <label for="level_04">ビジネス</label>
-                  </div>
+            </div>
+            <div class="p-userpage__next-lesson">
+              <h2 class="c-title"><span>次のレッスン</span></h2>
+              <div class="p-userpage__next-lesson__contents">
+                <ul class="p-userpage__next-lesson__list">
+                  <li class="p-userpage__next-lesson__list__item">
+                    <a href="">
+                      <div class="p-userpage__next-lesson__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                      <div class="p-userpage__next-lesson__list__item__title">
+                        レッスンタイトルレッスンタイトルレッスンタイトル
+                      </div>
+                    </a>
+                  </li>
+                  <li class="p-userpage__next-lesson__list__item">
+                    <a href="">
+                      <div class="p-userpage__next-lesson__list__item__date">
+                        2022.11.16 15:00
+                      </div>
+                      <div class="p-userpage__next-lesson__list__item__title">
+                        レッスンタイトルレッスンタイトルレッスンタイトル
+                      </div>
+                    </a>
+                  </li>
+                </ul>
+                <div class="p-userpage__next-lesson__none">
+                  まだ受講中のレッスンがありません。<br>
+                  レッスン希望を登録して自分のニーズと会う講師と会いましょう！<br>
+                  <a href="userpage-lesson.html">レッスン希望登録</a>
                 </div>
               </div>
-              <div class="c-checkbox">
-                <p class="c-checkbox__title">レッスン時間<span>※重複選択可能</span></p>
-                <div class="c-checkbox__flex__2col">
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="curse_01" name="curse" value="">
-                    <label for="curse_01">20分コース</label>
-                  </div>
-                  <div class="c-checkbox__flex__contents">
-                    <input type="checkbox" id="curse_02" name="curse" value="">
-                    <label for="curse_02">45分コース</label>
-                  </div>
+            </div>
+            <h2 class="c-title"><span>より効率的な方法で楽しめるレッスン</span></h2>
+            <p class="p-userpage__notice">“まずレッスン希望登録はしましたが、後はとうすればいいですか？”と思う方へ</p>
+            <ul class="p-userpage__list">
+              <li class="p-userpage__list__item">
+                <div class="p-userpage__list__item__icon">
+                  <img src="assets/images/lesson/sample01.svg">
                 </div>
-              </div>
-              <div class="c-textarea">
-                <p class="c-textarea__title">レッスン詳細内容</p>
-                <textarea class="textarea-160 textarea-resize" name="" placeholder="レッスン詳細内容"></textarea><br>
-              </div>
-              <div class="p-mypage-profile__submit">
-                <button class="js-sumit" onclick="location.href='mypage-lesson-complete.html'">プロフィール編集</button>
-              </div>
-            </form>
+                <div class="p-userpage__list__item__title">
+                  スケジュールを
+                  <span>登録してください。</span>
+                </div>
+                <div class="p-userpage__list__item__text">
+                  プロフィールをもっと詳しく入力してあなとのアピールポイントを生徒にアピールしてください。  
+                </div>
+                <a href="mypage-schedule.html" class="p-userpage__list__item__link">
+                  プロフィール編集
+                </a>
+              </li>
+              <li class="p-userpage__list__item">
+                <div class="p-userpage__list__item__icon">
+                  <img src="assets/images/lesson/sample01.svg">
+                </div>
+                <div class="p-userpage__list__item__title">
+                  プロフィールを
+                  <span>もっと詳しく</span>
+                </div>
+                <div class="p-userpage__list__item__text">
+                  スケジュール登録してより自分とニーズが会う生徒を待ってください。
+                </div>
+                <a href="mypage-profile.html" class="p-userpage__list__item__link">
+                  スケジュール登録
+                </a>
+              </li>
+              <li class="p-userpage__list__item">
+                <div class="p-userpage__list__item__icon">
+                  <img src="assets/images/lesson/sample01.svg">
+                </div>
+                <div class="p-userpage__list__item__title">
+                  レッスン希望を
+                  <span>探してください。</span>
+                </div>
+                <div class="p-userpage__list__item__text">
+                  生徒からの申し込みを待つだけではなく生徒にオファーしてより早めにレッスンを決めるのができます。
+                </div>
+                <a href="lesson-student.html" class="p-userpage__list__item__link">
+                  レッスン希望一覧
+                </a>
+              </li>
+              <li class="p-userpage__list__item">
+                <div class="p-userpage__list__item__icon">
+                  <img src="assets/images/lesson/sample01.svg">
+                </div>
+                <div class="p-userpage__list__item__title">
+                  自己PR動画を
+                  <span>アップしてください。</span>
+                </div>
+                <div class="p-userpage__list__item__text">
+                  あなたのアピールポイントをよりいい方法で生徒に伝えてください。
+                </div>
+                <a href="mypage-profile.html" class="p-userpage__list__item__link">
+                  動画登録申し込み
+                </a>
+              </li>
+            </ul>
           </section>
         </div>
       </div>


### PR DESCRIPTION
1.googlemeet管理ページ削除
→レッスンページから登録フィールド追加

2.レッスン登録ページへのリンク臨時削除

3.スケジュール登録ページをチェックボックスの形に変更

4.カレンダーページ追加(オファー、指名、レッスン表示)

5.指名中のページ追加

6.オファー中のページ追加

7.レッスン管理
登録中ページへのリンク臨時削除